### PR TITLE
Update to 3.3.8.7 release

### DIFF
--- a/org.dash.electrum.electrum_dash.json
+++ b/org.dash.electrum.electrum_dash.json
@@ -41,8 +41,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/akhavr/electrum-dash/releases/download/3.3.8.6/Dash-Electrum-3.3.8.6.tar.gz",
-                    "sha256": "71d0387a208bc45eeec08a7c779993ff841562613b11f6107f79e540dc1f7282"
+                    "url": "https://github.com/akhavr/electrum-dash/releases/download/3.3.8.7/Dash-Electrum-3.3.8.7.tar.gz",
+                    "sha256": "b5c2ad070864041b194da9dbbb0d112fa2296d2386abafd2672546d68e9d13d0"
                 },
                 {
                     "type": "patch",

--- a/org.dash.electrum.electrum_dash.metainfo.xml
+++ b/org.dash.electrum.electrum_dash.metainfo.xml
@@ -85,6 +85,40 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release date="2020-08-24" version="3.3.8.7">
+      <description>
+        <p>2020-08-24 release:</p>
+        <ul>
+          <li>
+            PrivateSend: support mixing on hardware wallets
+            (using ps_keystore)
+          </li>
+          <li>
+            PrivateSend: indicate waiting state (all mixed,
+            wait for more funds)
+          </li>
+          <li>
+            qt: fix exported files file mode
+          </li>
+          <li>
+            qt: allow hide warning for watch-only wallet
+          </li>
+          <li>
+            add "pay:" scheme to support anypayinc.com
+          </li>
+          <li>
+            allow bypass Tor proxy for Fiat rates loading
+            (option in Proxy settings)
+          </li>
+          <li>
+            protx_list: enhance network data processing
+          </li>
+          <li>
+            other qt gui fixes
+          </li>
+        </ul>
+      </description>
+    </release>
     <release date="2020-07-10" version="3.3.8.6">
       <description>
         <p>2020-07-10 release:</p>

--- a/python3-requirements-binaries.json
+++ b/python3-requirements-binaries.json
@@ -35,8 +35,8 @@
                 ],
                 "sources": [{
                     "type": "archive",
-                    "url" : "https://www.riverbankcomputing.com/static/Downloads/sip/4.19.23/sip-4.19.23.tar.gz",
-                    "sha256" : "22ca9bcec5388114e40d4aafd7ccd0c4fe072297b628d0c5cdfa2f010c0bc7e7"
+                    "url" : "https://www.riverbankcomputing.com/static/Downloads/sip/4.19.24/sip-4.19.24.tar.gz",
+                    "sha256" : "edcd3790bb01938191eef0f6117de0bf56d1136626c0ddb678f3a558d62e41e5"
                 }]
             }]
         },


### PR DESCRIPTION
- Update to 3.3.8.7 release
- Fix sip build (sip-4.19.23.tar.gz is missing on given URI)