### PR TITLE
Update runtime to 5.15-21.08

### DIFF
--- a/org.dash.electrum.electrum_dash.json
+++ b/org.dash.electrum.electrum_dash.json
@@ -40,13 +40,15 @@
             "--without-xshm",
             "--with-python=python3",
             "--disable-doc",
-            "--enable-codes=qrcode"
+            "--enable-codes=qrcode",
+            "--with-python_prefix=\"${FLATPAK_DEST}\"",
+            "--with-python_exe_prefix=\"${FLATPAK_DEST}\""
           ],
           "sources": [
             {
               "type": "git",
               "url": "https://git.linuxtv.org/zbar.git",
-              "tag": "0.23.1"
+              "tag": "0.23.92"
             },
             {
               "type": "script",

--- a/org.dash.electrum.electrum_dash.json
+++ b/org.dash.electrum.electrum_dash.json
@@ -2,7 +2,7 @@
     "id": "org.dash.electrum.electrum_dash",
     "sdk": "org.kde.Sdk",
     "runtime": "org.kde.Platform",
-    "runtime-version": "5.15",
+    "runtime-version": "5.15-21.08",
     "command": "electrum-dash",
     "finish-args": [
         /* Xorg support */

--- a/python3-requirements-binaries.json
+++ b/python3-requirements-binaries.json
@@ -68,11 +68,11 @@
         },
         {
             "name": "PyQt5",
-            "cleanup": ["/bin/sip", "/include", "/lib/python3.8/site-packages/*.pyi"],
+            "cleanup": ["/bin/sip", "/include", "/lib/python3.9/site-packages/*.pyi"],
             "config-opts": ["--disable-static", "--enable-x11"],
             "buildsystem": "simple",
             "build-commands": [
-                "python3 configure.py --confirm-license --no-docstrings --assume-shared --no-sip-files --no-qml-plugin --no-tools --no-qsci-api -d ${FLATPAK_DEST}/lib/python3.8/site-packages --sip=${FLATPAK_DEST}/bin/sip --sip-incdir=${FLATPAK_DEST}/include --stubsdir=${FLATPAK_DEST}/lib/python3.8/site-packages --disable=QtSensors --disable=QtWebEngine --disable=QtQuick --disable=QtQml --disable=QtTest --disable=QtWebChannel --disable=QtWebEngineCore --disable=QWebEngineWidgets --disable=QtQuickWidgets --disable=QtSql --disable=QtXmlPatterns --disable=QtMultimedia --disable=QtMultimediaWidgets --disable=QtLocation --disable=QtDesigner --disable=QtOpenGL --disable=QtBluetooth --disable=QtWebKit --disable=QtWebKitWidgets --disable=QtNfc --disable=QtPositioning",
+                "python3 configure.py --confirm-license --no-docstrings --assume-shared --no-sip-files --no-qml-plugin --no-tools --no-qsci-api -d ${FLATPAK_DEST}/lib/python3.9/site-packages --sip=${FLATPAK_DEST}/bin/sip --sip-incdir=${FLATPAK_DEST}/include --stubsdir=${FLATPAK_DEST}/lib/python3.9/site-packages --disable=QtSensors --disable=QtWebEngine --disable=QtQuick --disable=QtQml --disable=QtTest --disable=QtWebChannel --disable=QtWebEngineCore --disable=QWebEngineWidgets --disable=QtQuickWidgets --disable=QtSql --disable=QtXmlPatterns --disable=QtMultimedia --disable=QtMultimediaWidgets --disable=QtLocation --disable=QtDesigner --disable=QtOpenGL --disable=QtBluetooth --disable=QtWebKit --disable=QtWebKitWidgets --disable=QtNfc --disable=QtPositioning",
                 "make -j $FLATPAK_BUILDER_N_JOBS",
                 "make install"
             ],
@@ -93,7 +93,7 @@
                     "name": "sip",
                     "buildsystem": "simple",
                     "build-commands": [
-                        "python3 configure.py --sip-module PyQt5.sip -b ${FLATPAK_DEST}/bin -d ${FLATPAK_DEST}/lib/python3.8/site-packages -e ${FLATPAK_DEST}/include -v ${FLATPAK_DEST}/share/sip --stubsdir=${FLATPAK_DEST}/lib/python3.8/site-packages",
+                        "python3 configure.py --sip-module PyQt5.sip -b ${FLATPAK_DEST}/bin -d ${FLATPAK_DEST}/lib/python3.9/site-packages -e ${FLATPAK_DEST}/include -v ${FLATPAK_DEST}/share/sip --stubsdir=${FLATPAK_DEST}/lib/python3.9/site-packages",
                         "make -j $FLATPAK_BUILDER_N_JOBS",
                         "make install"
                     ],

--- a/python3-requirements-hw.json
+++ b/python3-requirements-hw.json
@@ -585,7 +585,7 @@
             "name": "python3-wheel",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"wheel==0.36.2\""
+                "pip3 install --ignore-installed --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"wheel==0.36.2\""
             ],
             "sources": [
                 {


### PR DESCRIPTION
The 5.15 version of the KDE Runtime is based on the 20.08 version of the Freedesktop Runtime and will stay as-is to keep compatibility.
The 5.15-21.08 version of the KDE Runtime is based on the 21.08 Freedesktop one. The Qt/KDE Libraries are mostyl similar between the two runtimes.

This change is mostly maintenance to keep the base runtime updated.